### PR TITLE
fix channel gap wrong channel readout in 4 channel mode

### DIFF
--- a/RigolWFM/channel.py
+++ b/RigolWFM/channel.py
@@ -63,7 +63,7 @@ def engineering_string(number, n_digits):
 #    x0[0::2] = data[offset_1:offset_1+pagesize]
 #    x0[1::2] = data[offset_2:offset_2+pagesize]
 
-def _channel_bytes(enabled_count, data, stride):
+def _channel_bytes(channel, enabled_count, data, stride):
     """
     Return right series of bytes for a channel for 1000Z scopes.
 
@@ -80,6 +80,7 @@ def _channel_bytes(enabled_count, data, stride):
         CH4CH3CH2CH1
 
     Args:
+        channel: the physical scope channel
         enabled_count: the number of enabled channels before this one
         data:          object containing the raw data structures
     Returns
@@ -95,13 +96,13 @@ def _channel_bytes(enabled_count, data, stride):
             raw_bytes = np.array((np.uint16(data.raw2) & 0xFF00) >> 8, dtype=np.uint8)
 
     if stride == 4:
-        if enabled_count == 3:
+        if channel == 3:
             raw_bytes = np.array(np.uint32(data.raw4)
                                  & 0x000000FF, dtype=np.uint8)
-        elif enabled_count == 2:
+        elif channel == 2:
             raw_bytes = np.array(
                 (np.uint32(data.raw4) & 0x0000FF00) >> 8, dtype=np.uint8)
-        elif enabled_count == 1:
+        elif channel == 1:
             raw_bytes = np.array(
                 (np.uint32(data.raw4) & 0x00FF0000) >> 16, dtype=np.uint8)
         else:
@@ -282,7 +283,7 @@ class Channel():
         self.y_offset = w.header.ch[ch-1].y_offset
 
         if self.enabled:
-            self.raw = _channel_bytes(enabled_count, w.data, self.stride)
+            self.raw = _channel_bytes(ch-1,enabled_count, w.data, self.stride)
 
         self.calc_times_and_volts()
 


### PR DESCRIPTION
With my DS1054Z, firmware version 00.04.04.SP3, i found the following bug when importing WFM files. 
Enable channels 1,2 and 4. After importing the WFM file, the raw data of the 4th channel was always 0. I tracked the bug down to the _channel_bytes function in channel.py. If 3 channels are enabled, the data of one sample is still stored in 4 bytes, but when selecting channel 1,2 and 4, in the channel_bytes function, the 3rd byte was readout instead of the 4th.
I tested enabling channel 1,2,3 and 1,3,4 and 1,2,4 and with my bugfix, every time the right channel number and the right RAW data was assigned to the right channel in the array. So I think I tested all edge cases. In 1 or 2 channel sampling mode, this is not important, as in two sampling mode, you cannot have gaps between channels and there the old code worked fine.
I have no other osciloscopes from the DS1000Z series to test this on. But it seems to be the most logical way to save the sampling data anyway, so I think it is the same across the whole range.

## Tested scenarios:
ch1: UART, ch2: off, ch3: square, ch4: sine
![ch1: UART, ch2: off, ch3: square, ch4: sine](https://user-images.githubusercontent.com/1377260/111787299-122cf780-88bf-11eb-85b9-09b870335e2c.png)
![import results](https://user-images.githubusercontent.com/1377260/111787649-7a7bd900-88bf-11eb-9ddf-c3c574bc8f8b.png)

ch1: UART, ch2: square, ch3: off, ch4: sine
![ch1: UART, ch2: square, ch3: off, ch4: sine](https://user-images.githubusercontent.com/1377260/111787316-16f1ab80-88bf-11eb-840f-c8e0269ad820.png)
![import results](https://user-images.githubusercontent.com/1377260/111787690-89628b80-88bf-11eb-8343-5324cec46355.png)

ch1: UART, ch2: square, ch3: sine, ch4: of
![ch1: UART, ch2: square, ch3: sine, ch4: off](https://user-images.githubusercontent.com/1377260/111787323-18bb6f00-88bf-11eb-8749-6eb80c9c3e21.png)
![import results](https://user-images.githubusercontent.com/1377260/111787699-8b2c4f00-88bf-11eb-8838-e30b0dd2468c.png)


